### PR TITLE
Clamp -> Cramp

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,62 +1,39 @@
-Clamps (ie. cuts off) an HTML element's content by adding ellipsis to it if the 
+Cramps (ie. cuts off) an HTML element's content by adding ellipsis to it if the 
 content inside is too long.
 
+Also supports cramping an element containing non-text elements (images, etc).
 
 # Sample Usage
 
 <pre>
 //Single line
-$clamp(myHeader, {clamp: 1});
+$cramp(myHeader, {cramp: 1});
 
 //Multi-line
-$clamp(myHeader, {clamp: 3});
+$cramp(myHeader, {cramp: 3});
 
-//Auto-clamp based on available height
-$clamp(myParagraph, {clamp: 'auto'});
+//Auto-cramp based on available height
+$cramp(myParagraph, {cramp: 'auto'});
 
-//Auto-clamp based on a fixed element height
-$clamp(myParagraph, {clamp: '35px'});
+//Auto-cramp based on a fixed element height
+$cramp(myParagraph, {cramp: '35px'});
 </pre>
 
-The $clamp method is the primary way of interacting with Clamp.js, and it takes two
-arguments. The first is the element which should be clamped, and the second is an
+The $cramp method is the primary way of interacting with Cramp.js, and it takes two
+arguments. The first is the element which should be cramped, and the second is an
 Object with options in JSON notation.
 
 
 # Options
 
-**clamp** _(Number | String | 'auto')_. This controls where and when to clamp the 
+**cramp** _(Number | String | 'auto')_. This controls where and when to cramp the 
 text of an element. Submitting a number controls the number of lines that should
 be displayed. Second, you can submit a CSS value (in px or em) that controls the
 height of the element as a String. Finally, you can submit the word 'auto' as a string.
 Auto will try to fill up the available space with the content and then automatically
-clamp once content no longer fits. This last option should only be set if a static 
+cramp once content no longer fits. This last option should only be set if a static 
 height is being set on the element elsewhere (such as through CSS) otherwise no 
-clamping will be done.
-
-**useNativeClamp** _(Boolean)_. Enables or disables using the native -webkit-line-clamp
-in a supported browser (ie. Webkit). It defaults to true if you're using Webkit,
-but it can behave wonky sometimes so you can set it to false to use the JavaScript-
-based solution.
+cramping will be done.
 
 **truncationChar** _(String)_. The character to insert at the end of the HTML element
 after truncation is performed. This defaults to an ellipsis (…).
-
-**truncationHTML** _(String)_. A string of HTML to insert before the truncation character.
-This is useful if you'd like to add a "Read more" link or some such thing at the end of
-your clamped node.
-
-**splitOnChars** _(Array)_. Determines what characters to use to chunk an element into
-smaller pieces. Version 0.1 of Clamp.js would always remove each individual character
-to check for fit. With v0.2, you now have an option to pass a list of characters it
-can use. For example, it you pass an array of ['.', ',', ' '] then it will first remove
-sentences, then remove comma-phrases, and remove words, and finally remove individual
-characters to try and find the correct height. This will lead to increased performance
-and less looping when removing larger pieces of text (such as in paragraphs). The default
-is set to remove sentences (periods), hypens, en-dashes, em-dashes, and finally words 
-(spaces). Removing by character is always enabled as the last attempt no matter what
-is submitted in the array.
-
-**animate** _(Boolean)_. Silly little easter-egg that, when set to true, will animate
-removing individual characters from the end of the element until the content fits.
-Defaults to false.

--- a/clamp.js
+++ b/clamp.js
@@ -1,261 +1,183 @@
 /*!
-* Clamp.js 0.5.1
+* Cramp.js 0.1.0
 *
 * Copyright 2011-2013, Joseph Schmitt http://joe.sh
 * Released under the WTFPL license
-* http://sam.zoy.org/wtfpl/
+* http://wtfpl.org
+*
+* Copyright (c) 2014 by Curalate, Inc.
+*
 */
 
-(function(){
-    /**
-     * Clamps a text node.
-     * @param {HTMLElement} element. Element containing the text node to clamp.
-     * @param {Object} options. Options to pass to the clamper.
-     */
-    function clamp(element, options) {
-        options = options || {};
+(function(window){
 
-        var self = this,
-            win = window,
-            opt = {
-                clamp:              options.clamp || 2,
-                useNativeClamp:     typeof(options.useNativeClamp) != 'undefined' ? options.useNativeClamp : true,
-                splitOnChars:       options.splitOnChars || ['.', '-', '–', '—', ' '], //Split on sentences (periods), hypens, en-dashes, em-dashes, and words (spaces).
-                animate:            options.animate || false,
-                truncationChar:     options.truncationChar || '…',
-                truncationHTML:     options.truncationHTML
-            },
-
-            sty = element.style,
-            originalText = element.innerHTML,
-
-            supportsNativeClamp = typeof(element.style.webkitLineClamp) != 'undefined',
-            clampValue = opt.clamp,
-            isCSSValue = clampValue.indexOf && (clampValue.indexOf('px') > -1 || clampValue.indexOf('em') > -1),
-            truncationHTMLContainer;
-            
-        if (opt.truncationHTML) {
-            truncationHTMLContainer = document.createElement('span');
-            truncationHTMLContainer.innerHTML = opt.truncationHTML;
-        }
-
+    var TEXT_NODE = 3,
+        DEFAULT_MAX_LINES = 2;
 
 // UTILITY FUNCTIONS __________________________________________________________
 
-        /**
-         * Return the current style for an element.
-         * @param {HTMLElement} elem The element to compute.
-         * @param {string} prop The style property.
-         * @returns {number}
-         */
-        function computeStyle(elem, prop) {
-            if (!win.getComputedStyle) {
-                win.getComputedStyle = function(el, pseudo) {
-                    this.el = el;
-                    this.getPropertyValue = function(prop) {
-                        var re = /(\-([a-z]){1})/g;
-                        if (prop == 'float') prop = 'styleFloat';
-                        if (re.test(prop)) {
-                            prop = prop.replace(re, function () {
-                                return arguments[2].toUpperCase();
-                            });
+    /**
+     * Return the current style for an element.
+     * @param {HTMLElement} element The element to compute.
+     * @param {string} prop The style property.
+     * @returns {number}
+     */
+    function computeStyle(element, prop) {
+        if (!window.getComputedStyle) {
+            window.getComputedStyle = function(el) {
+                this.el = el;
+                this.getPropertyValue = function(prop) {
+                    var re = /(\-([a-z]){1})/g;
+                    if (prop == 'float') prop = 'styleFloat';
+                    if (re.test(prop)) {
+                        prop = prop.replace(re, function () {
+                            return arguments[2].toUpperCase();
+                        });
+                    }
+                    return el.currentStyle && el.currentStyle[prop] ? el.currentStyle[prop] : null;
+                }
+                return this;
+            }
+        }
+
+        return window.getComputedStyle(element, null).getPropertyValue(prop);
+    };
+
+    /**
+     * Returns the maximum number of lines of text that should be rendered based
+     * on the current height of the element and the line-height of the text.
+     */
+    function getMaxLines(element, height) {
+        var availHeight = height || element.clientHeight,
+            lineHeight = getLineHeight(element);
+
+        return Math.max(Math.floor(availHeight/lineHeight), 0);
+    };
+
+    /**
+     * Returns the line-height of an element as an integer.
+     */
+    function getLineHeight(element) {
+        var lh = computeStyle(element, 'line-height');
+        if (lh == 'normal') {
+            // Normal line heights vary from browser to browser. The spec recommends
+            // a value between 1.0 and 1.2 of the font size. Using 1.1 to split the diff.
+            lh = parseInt(computeStyle(element, 'font-size')) * 1.2;
+        }
+        return parseInt(lh);
+    };
+
+    function getElementHeight(element) {
+        return element.clientHeight;
+    };
+
+    /**
+     * Returns the max number of lines we will allow before cramping.
+     */
+    function parseCrampValue(crampValue) {
+        var isCSSValue;
+
+        if (!crampValue) {
+            return DEFAULT_MAX_LINES;
+        }
+
+        isCSSValue = crampValue.indexOf && (crampValue.indexOf('px') > -1 || crampValue.indexOf('em') > -1);
+
+        if (crampValue == 'auto') {
+            return getMaxLines(element);
+        }
+        else if (isCSSValue) {
+            return getMaxLines(element, parseInt(crampValue));
+        } else {
+            return crampValue;
+        }
+    };
+
+    /**
+     * Cramps a text node.
+     * @param {HTMLElement} element. Element containing the text node to clamp.
+     */
+    function cramp(element, opts) {
+        var options = opts || {},
+            original = element.innerHTML,
+            cramped,
+            maxLines = parseCrampValue(options.cramp || 2),
+            truncationText = options.truncationChar || "…";
+
+        var truncate = function(maxLines) {
+            var i, text, parentNode, spaceIndex,
+                nodes = element.childNodes;
+
+            for (i = nodes.length - 1; i >= 0; i--) {
+                node = nodes[i],
+                parentNode = node.parentNode;
+
+                if (node.nodeType === TEXT_NODE) {
+                    text = node.nodeValue;
+                    while (text.length > 0) {
+
+                        spaceIndex = text.lastIndexOf(" ");
+
+                        if (spaceIndex != -1) {
+                            // Remove the last word
+                            text = text.slice(0, spaceIndex);
+                        } else {
+                            // Remove the last letter
+                            text = text.slice(0, text.length - 1);
                         }
-                        return el.currentStyle && el.currentStyle[prop] ? el.currentStyle[prop] : null;
+
+                        // Strip word/letter and add the "..." string
+                        node.nodeValue = text + truncationText;
+
+                        // Does the content fit?
+                        if (isCramped(maxLines)) {
+                            return element.innerHTML;
+                        } else {
+                            text = text.slice(0, text.length - truncationText.length); // Remove the "..." string
+                        }
                     }
-                    return this;
-                }
-            }
 
-            return win.getComputedStyle(elem, null).getPropertyValue(prop);
-        }
+                    // We've removed all the text and it's not cramped yet - remove the node itself
+                    parentNode.removeChild(node);
 
-        /**
-         * Returns the maximum number of lines of text that should be rendered based
-         * on the current height of the element and the line-height of the text.
-         */
-        function getMaxLines(height) {
-            var availHeight = height || element.clientHeight,
-                lineHeight = getLineHeight(element);
+                } else {
 
-            return Math.max(Math.floor(availHeight/lineHeight), 0);
-        }
+                    // Remove the last element
+                    parentNode.removeChild(node);
 
-        /**
-         * Returns the maximum height a given element should have based on the line-
-         * height of the text and the given clamp value.
-         */
-        function getMaxHeight(clmp) {
-            var lineHeight = getLineHeight(element);
-            return lineHeight * clmp;
-        }
+                    // Add the "..." string
+                    parentNode.appendChild(new Text(truncationText));
 
-        /**
-         * Returns the line-height of an element as an integer.
-         */
-        function getLineHeight(elem) {
-            var lh = computeStyle(elem, 'line-height');
-            if (lh == 'normal') {
-                // Normal line heights vary from browser to browser. The spec recommends
-                // a value between 1.0 and 1.2 of the font size. Using 1.1 to split the diff.
-                lh = parseInt(computeStyle(elem, 'font-size')) * 1.2;
-            }
-            return parseInt(lh);
-        }
-
-
-// MEAT AND POTATOES (MMMM, POTATOES...) ______________________________________
-        var splitOnChars = opt.splitOnChars.slice(0),
-            splitChar = splitOnChars[0],
-            chunks,
-            lastChunk;
-        
-        /**
-         * Gets an element's last child. That may be another node or a node's contents.
-         */
-        function getLastChild(elem) {
-            //Current element has children, need to go deeper and get last child as a text node
-            if (elem.lastChild.children && elem.lastChild.children.length > 0) {
-                return getLastChild(Array.prototype.slice.call(elem.children).pop());
-            }
-            //This is the absolute last child, a text node, but something's wrong with it. Remove it and keep trying
-            else if (!elem.lastChild || !elem.lastChild.nodeValue || elem.lastChild.nodeValue == '' || elem.lastChild.nodeValue == opt.truncationChar) {
-                elem.lastChild.parentNode.removeChild(elem.lastChild);
-                return getLastChild(element);
-            }
-            //This is the last child we want, return it
-            else {
-                return elem.lastChild;
-            }
-        }
-        
-        /**
-         * Removes one character at a time from the text until its width or
-         * height is beneath the passed-in max param.
-         */
-        function truncate(target, maxHeight) {
-            if (!maxHeight) {return;}
-            
-            /**
-             * Resets global variables.
-             */
-            function reset() {
-                splitOnChars = opt.splitOnChars.slice(0);
-                splitChar = splitOnChars[0];
-                chunks = null;
-                lastChunk = null;
-            }
-            
-            var nodeValue = target.nodeValue.replace(opt.truncationChar, '');
-            
-            //Grab the next chunks
-            if (!chunks) {
-                //If there are more characters to try, grab the next one
-                if (splitOnChars.length > 0) {
-                    splitChar = splitOnChars.shift();
-                }
-                //No characters to chunk by. Go character-by-character
-                else {
-                    splitChar = '';
-                }
-                
-                chunks = nodeValue.split(splitChar);
-            }
-            
-            //If there are chunks left to remove, remove the last one and see if
-            // the nodeValue fits.
-            if (chunks.length > 1) {
-                // console.log('chunks', chunks);
-                lastChunk = chunks.pop();
-                // console.log('lastChunk', lastChunk);
-                applyEllipsis(target, chunks.join(splitChar));
-            }
-            //No more chunks can be removed using this character
-            else {
-                chunks = null;
-            }
-            
-            //Insert the custom HTML before the truncation character
-            if (truncationHTMLContainer) {
-                target.nodeValue = target.nodeValue.replace(opt.truncationChar, '');
-                element.innerHTML = target.nodeValue + ' ' + truncationHTMLContainer.innerHTML + opt.truncationChar;
-            }
-
-            //Search produced valid chunks
-            if (chunks) {
-                //It fits
-                if (element.clientHeight <= maxHeight) {
-                    //There's still more characters to try splitting on, not quite done yet
-                    if (splitOnChars.length >= 0 && splitChar != '') {
-                        applyEllipsis(target, chunks.join(splitChar) + splitChar + lastChunk);
-                        chunks = null;
-                    }
-                    //Finished!
-                    else {
+                    // Does the content fit?
+                    if (isCramped(maxLines)) {
                         return element.innerHTML;
+                    } else {
+                        parentNode.removeChild(parentNode.lastChild); // Remove the "..." string
                     }
                 }
             }
-            //No valid chunks produced
-            else {
-                //No valid chunks even when splitting by letter, time to move
-                //on to the next node
-                if (splitChar == '') {
-                    applyEllipsis(target, '');
-                    target = getLastChild(element);
-                    
-                    reset();
-                }
-            }
-            
-            //If you get here it means still too big, let's keep truncating
-            if (opt.animate) {
-                setTimeout(function() {
-                    truncate(target, maxHeight);
-                }, opt.animate === true ? 10 : opt.animate);
-            }
-            else {
-                return truncate(target, maxHeight);
-            }
-        }
-        
-        function applyEllipsis(elem, str) {
-            elem.nodeValue = str + opt.truncationChar;
-        }
 
+            return element.innerHTML;
+        };
+
+        var isCramped = function(lines) {
+            return getLineHeight(element) * lines >= getElementHeight(element);
+        };
 
 // CONSTRUCTOR ________________________________________________________________
 
-        if (clampValue == 'auto') {
-            clampValue = getMaxLines();
-        }
-        else if (isCSSValue) {
-            clampValue = getMaxLines(parseInt(clampValue));
+        if (isCramped(maxLines)) {
+            cramped = null;
+        } else {
+            cramped = truncate(maxLines);
         }
 
-        var clampedText;
-        if (supportsNativeClamp && opt.useNativeClamp) {
-            sty.overflow = 'hidden';
-            sty.textOverflow = 'ellipsis';
-            sty.webkitBoxOrient = 'vertical';
-            sty.display = '-webkit-box';
-            sty.webkitLineClamp = clampValue;
-
-            if (isCSSValue) {
-                sty.height = opt.clamp + 'px';
-            }
-        }
-        else {
-            var height = getMaxHeight(clampValue);
-            if (height <= element.clientHeight) {
-                clampedText = truncate(getLastChild(element), height);
-            }
-        }
-        
         return {
-            'original': originalText,
-            'clamped': clampedText
-        }
+            'original': original,
+            'cramped': cramped
+        };
     }
 
-    window.$clamp = clamp;
-})();
+    window.$cramp = cramp;
+
+})(window);


### PR DESCRIPTION
Includes the following changes:
- Reimplements clamp.js to support clamping of non-textual content, such as images.
- Replace recursive logic with more straightforward iterative logic.
- Removes some unnecessary options.
- No longer will look more than one-level deep to clamp textual content (e.g. clamp.js will look inside a "strong" element and clamp text inside that element - cramp will take the all-or-nothing approach of including or excluding the entire "strong" element.

Future Work:
- Performance is an issue when cramping a ton of elements at once.  We could try to fix this by reducing the number of elements we cramp at a given time and/or using a less naive approach to cramping content (e.g. don't always start your search from the end).
