### PR TITLE
DEV-16304: Use document.createTextNode() instead of new Text()

### DIFF
--- a/clamp.js
+++ b/clamp.js
@@ -146,7 +146,7 @@
                     parentNode.removeChild(node);
 
                     // Add the "..." string
-                    parentNode.appendChild(new Text(truncationText));
+                    parentNode.appendChild(document.createTextNode(truncationText));
 
                     // Does the content fit?
                     if (isCramped(maxLines)) {


### PR DESCRIPTION
`new Text()` does not work on phantomjs and is nonstandard.

Replacing it with `document.createTextNode()` produces the same results, same return type, etc. but is actually a method outlined in the standards.